### PR TITLE
Not receiving messages fix

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1784,7 +1784,7 @@ RegisterNetEvent('qb-phone:client:GetCalled', function(CallerNumber, CallId, Ano
 end)
 
 RegisterNetEvent('qb-phone:client:UpdateMessages', function(ChatMessages, SenderNumber, New)
-    local NumberKey = GetKeyByNumber(SenderNumber)
+    local NumberKey = GetKeyByNumber(tostring(SenderNumber))
 
     if New then
         PhoneData.Chats[#PhoneData.Chats+1] = {

--- a/client/main.lua
+++ b/client/main.lua
@@ -115,7 +115,7 @@ local function GetKeyByNumber(Number)
     local retval = nil
     if PhoneData.Chats then
         for k, v in pairs(PhoneData.Chats) do
-            if v.number == Number then
+            if v.number == tostring(Number) then
                 retval = k
             end
         end
@@ -1784,7 +1784,7 @@ RegisterNetEvent('qb-phone:client:GetCalled', function(CallerNumber, CallId, Ano
 end)
 
 RegisterNetEvent('qb-phone:client:UpdateMessages', function(ChatMessages, SenderNumber, New)
-    local NumberKey = GetKeyByNumber(tostring(SenderNumber))
+    local NumberKey = GetKeyByNumber(SenderNumber)
 
     if New then
         PhoneData.Chats[#PhoneData.Chats+1] = {


### PR DESCRIPTION
**Not receiving messages**
This fix is quite odd because this problem didn't exist before it just appeared from nowhere. Anyway so this was a hard bug to find because me and some buddies ended up searching for why the messages break after updating the 2nd time for like 2 days. Anyway so the problem was when a player sends the first message it sends to the other player with no issues, but whenever the player sends a second message the code breaks and the message that the player had wrote doesn't appear for you or the other player. So we found out that for some reason when messages are being updated the sender number changes from a string type to number and the GetKeyByNumber function breaks. So the solution was when the messages are being updated we force the sender number to be string. No clue why this problem even appeared, but thought I would open a pr if somebody would have the same issue that we did.




