### PR TITLE
chore(qbx-phone/fxmanifest): remove undeclared font files from manifest

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -28,9 +28,6 @@ files {
     'html/js/*.js',
     'html/img/*.png',
     'html/css/*.css',
-    'html/fonts/*.ttf',
-    'html/fonts/*.otf',
-    'html/fonts/*.woff',
     'html/img/backgrounds/*.png',
     'html/img/apps/*.png',
 }


### PR DESCRIPTION
## Description

![image](https://github.com/Qbox-project/qbx-phone/assets/46171436/1b7ba6fb-611a-4ca4-84f7-7096a28b9135)

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
